### PR TITLE
Added examples for Uno and Adafruit Motor Shield v1

### DIFF
--- a/examples/ESP32/LEDControlBluetooth/LEDControlBluetooth.ino
+++ b/examples/ESP32/LEDControlBluetooth/LEDControlBluetooth.ino
@@ -20,6 +20,10 @@ void setup() {
 
 void loop() {
     AlfredoConnect.update();
-    if (AlfredoConnect.keyHeld(Key::W)) digitalWrite(2, HIGH);
-    else digitalWrite(LED_BUILTIN, LOW);
+    
+    if (AlfredoConnect.keyHeld(Key::W)) {
+        digitalWrite(LED_BUILTIN, HIGH);
+    } else {
+        digitalWrite(LED_BUILTIN, LOW);
+    }
 }

--- a/examples/ESP32/LEDControlSerial/LEDControlSerial.ino
+++ b/examples/ESP32/LEDControlSerial/LEDControlSerial.ino
@@ -1,13 +1,13 @@
 /**
- * Lights the ESP32's built-in LED when the "W" key is pressed in AlfredoConnect
- * connected to the ESP32's hardware serial.
+ * Lights the ESP32's built-in LED when the "W" key is pressed in AlfredoConnect while
+ * connected to the ESP32's hardware serial (typically over USB).
  * 
  * TODO: Link basic setup here (board files, how to upload, how to pair Bluetooth, how to find and open port)
  */
 
 #include <AlfredoConnect.h>
 
-const int LED_BUILTIN = 2;
+static const int LED_BUILTIN = 2;
 
 void setup() {
     Serial.begin(9600);
@@ -17,6 +17,10 @@ void setup() {
 
 void loop() {
     AlfredoConnect.update();
-    if (AlfredoConnect.keyHeld(Key::W)) digitalWrite(2, HIGH);
-    else digitalWrite(2, LOW);
+
+    if (AlfredoConnect.keyHeld(Key::W)) {
+        digitalWrite(LED_BUILTIN, HIGH);
+    } else {
+        digitalWrite(LED_BUILTIN, LOW);
+    }
 }

--- a/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotGamepad/DefaultArcadeBotGamepad.ino
+++ b/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotGamepad/DefaultArcadeBotGamepad.ino
@@ -11,8 +11,8 @@
 /* These pins are labeled from the board's perspective, so the BLUETOOTH_RX
  * (receive) pin on the board connects to TX (transmit) on the Bluetooth
  * module, and vice versa. */
-static const int BLUETOOTH_RX = A0;
-static const int BLUETOOTH_TX = A1;
+static const int BLUETOOTH_RX = A3;
+static const int BLUETOOTH_TX = A2;
 
 SoftwareSerial bluetooth(BLUETOOTH_RX, BLUETOOTH_TX);
 

--- a/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotGamepad/DefaultArcadeBotGamepad.ino
+++ b/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotGamepad/DefaultArcadeBotGamepad.ino
@@ -1,0 +1,63 @@
+/**
+ * Example code for a robot using an Arduino and an Adafruit Motor Shield v1 controlled
+ * with a gamepad from AlfredoConnect. The AFMotor library, for the Adafruit Motor Shield
+ * v1 can be found at https://github.com/adafruit/Adafruit-Motor-Shield-library.
+ */
+
+#include <AlfredoConnect.h>
+#include <SoftwareSerial.h>
+#include <AFMotor.h>
+
+/* These pins are labeled from the board's perspective, so the BLUETOOTH_RX
+ * (receive) pin on the board connects to TX (transmit) on the Bluetooth
+ * module, and vice versa. */
+static const int BLUETOOTH_RX = A0;
+static const int BLUETOOTH_TX = A1;
+
+SoftwareSerial bluetooth(BLUETOOTH_RX, BLUETOOTH_TX);
+
+AF_DCMotor leftMotor(1);
+AF_DCMotor rightMotor(2);
+
+void setup() {
+    bluetooth.begin(9600);
+    AlfredoConnect.begin(bluetooth);
+}
+
+void loop() {
+    AlfredoConnect.update();
+
+    if (AlfredoConnect.getGamepadCount() >= 1) {
+        arcadeDrive(-AlfredoConnect.getAxis(0, 1), AlfredoConnect.getAxis(0, 0));
+    }
+}
+
+void arcadeDrive(float throttle, float rotation) {
+    float leftPower = 0;
+    float rightPower = 0;
+    float maxInput = (throttle > 0 ? 1 : -1) * max(fabs(throttle), fabs(rotation));
+    if (throttle > 0) {
+        if (rotation > 0) {
+            leftPower = maxInput;
+            rightPower = throttle - rotation;
+        } else {
+            leftPower = throttle + rotation;
+            rightPower = maxInput;
+        }
+    } else {
+        if (rotation > 0) {
+            leftPower = throttle + rotation;
+            rightPower = maxInput;
+        } else {
+            leftPower = maxInput;
+            rightPower = throttle - rotation;
+        }
+    }
+    setMotor(leftMotor, leftPower);
+    setMotor(rightMotor, rightPower);
+}
+
+void setMotor(AF_DCMotor motor, float power) {
+    motor.run(power > 0 ? FORWARD : BACKWARD);
+    motor.setSpeed(fabs(power * 255));
+}

--- a/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotKeyboard/DefaultArcadeBotKeyboard.ino
+++ b/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotKeyboard/DefaultArcadeBotKeyboard.ino
@@ -11,8 +11,8 @@
 /* These pins are labeled from the board's perspective, so the BLUETOOTH_RX
  * (receive) pin on the board connects to TX (transmit) on the Bluetooth
  * module, and vice versa. */
-static const int BLUETOOTH_RX = A0;
-static const int BLUETOOTH_TX = A1;
+static const int BLUETOOTH_RX = A3;
+static const int BLUETOOTH_TX = A2;
 
 SoftwareSerial bluetooth(BLUETOOTH_RX, BLUETOOTH_TX);
 

--- a/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotKeyboard/DefaultArcadeBotKeyboard.ino
+++ b/examples/Uno/Adafruit-Motor-Shield-v1/DefaultArcadeBotKeyboard/DefaultArcadeBotKeyboard.ino
@@ -1,0 +1,75 @@
+/**
+ * Example code for a robot using an Arduino and an Adafruit Motor Shield v1 controlled
+ * with a gamepad from AlfredoConnect. The AFMotor library, for the Adafruit Motor Shield
+ * v1 can be found at https://github.com/adafruit/Adafruit-Motor-Shield-library.
+ */
+
+#include <AlfredoConnect.h>
+#include <SoftwareSerial.h>
+#include <AFMotor.h>
+
+/* These pins are labeled from the board's perspective, so the BLUETOOTH_RX
+ * (receive) pin on the board connects to TX (transmit) on the Bluetooth
+ * module, and vice versa. */
+static const int BLUETOOTH_RX = A0;
+static const int BLUETOOTH_TX = A1;
+
+SoftwareSerial bluetooth(BLUETOOTH_RX, BLUETOOTH_TX);
+
+AF_DCMotor leftMotor(1);
+AF_DCMotor rightMotor(2);
+
+void setup() {
+    bluetooth.begin(9600);
+    AlfredoConnect.begin(bluetooth);
+}
+
+void loop() {
+    float throttle = 0;
+    float rotation = 0;
+
+    if (AlfredoConnect.keyHeld(Key::W)) {
+        throttle = 1;
+    } else if (AlfredoConnect.keyHeld(Key::S)) {
+        throttle = -1;
+    }
+    if (AlfredoConnect.keyHeld(Key::A)) {
+        rotation = -1;
+    } else if (AlfredoConnect.keyHeld(Key::D)) {
+        rotation = 1;
+    }
+
+    arcadeDrive(throttle, rotation);
+
+    AlfredoConnect.update();
+}
+
+void arcadeDrive(float throttle, float rotation) {
+    float leftPower = 0;
+    float rightPower = 0;
+    float maxInput = (throttle > 0 ? 1 : -1) * max(fabs(throttle), fabs(rotation));
+    if (throttle > 0) {
+        if (rotation > 0) {
+            leftPower = maxInput;
+            rightPower = throttle - rotation;
+        } else {
+            leftPower = throttle + rotation;
+            rightPower = maxInput;
+        }
+    } else {
+        if (rotation > 0) {
+            leftPower = throttle + rotation;
+            rightPower = maxInput;
+        } else {
+            leftPower = maxInput;
+            rightPower = throttle - rotation;
+        }
+    }
+    setMotor(leftMotor, leftPower);
+    setMotor(rightMotor, rightPower);
+}
+
+void setMotor(AF_DCMotor motor, float power) {
+    motor.run(power > 0 ? FORWARD : BACKWARD);
+    motor.setSpeed(fabs(power * 255));
+}

--- a/examples/Uno/LEDControlBluetooth/LEDControlBluetooth.ino
+++ b/examples/Uno/LEDControlBluetooth/LEDControlBluetooth.ino
@@ -11,8 +11,8 @@
 /* These pins are labeled from the board's perspective, so the BLUETOOTH_RX
  * (receive) pin on the board connects to TX (transmit) on the Bluetooth
  * module, and vice versa. */
-static const int BLUETOOTH_RX = A0;
-static const int BLUETOOTH_TX = A1;
+static const int BLUETOOTH_RX = A3;
+static const int BLUETOOTH_TX = A2;
 
 SoftwareSerial bluetooth(BLUETOOTH_RX, BLUETOOTH_TX);
 

--- a/examples/Uno/LEDControlBluetooth/LEDControlBluetooth.ino
+++ b/examples/Uno/LEDControlBluetooth/LEDControlBluetooth.ino
@@ -1,23 +1,33 @@
 /**
- * Lights an Arduino or clone board's built-in LED when the "W" key is pressed in AlfredoConnect
- * while connected to the ESP32's Bluetooth.
+ * Lights an Arduino or clone board's built-in LED when the "W" key is pressed in
+ * AlfredoConnect while connected to the ESP32's Bluetooth.
  * 
  * TODO: Link basic setup here (board files, how to upload, how to pair Bluetooth, how to find and open port)
  */
 
 #include <AlfredoConnect.h>
-#include <BluetoothSerial.h>
+#include <SoftwareSerial.h>
 
-BluetoothSerial bluetooth;
+/* These pins are labeled from the board's perspective, so the BLUETOOTH_RX
+ * (receive) pin on the board connects to TX (transmit) on the Bluetooth
+ * module, and vice versa. */
+static const int BLUETOOTH_RX = A0;
+static const int BLUETOOTH_TX = A1;
+
+SoftwareSerial bluetooth(BLUETOOTH_RX, BLUETOOTH_TX);
 
 void setup() {
-    bluetooth.begin("ESP32 Bluetooth");
+    bluetooth.begin(9600);
     AlfredoConnect.begin(bluetooth);
     pinMode(LED_BUILTIN, OUTPUT);
 }
 
 void loop() {
     AlfredoConnect.update();
-    if (AlfredoConnect.keyHeld(Key::W)) digitalWrite(2, HIGH);
-    else digitalWrite(LED_BUILTIN, LOW);
+
+    if (AlfredoConnect.keyHeld(Key::W)) {
+        digitalWrite(LED_BUILTIN, HIGH);
+    } else {
+        digitalWrite(LED_BUILTIN, LOW);
+    }
 }

--- a/examples/Uno/LEDControlSerial/LEDControlSerial.ino
+++ b/examples/Uno/LEDControlSerial/LEDControlSerial.ino
@@ -1,6 +1,6 @@
 /**
  * Lights an Arduino or clone board's built-in LED when the "W" key is pressed in AlfredoConnect
- * while connected to the board's hardware serial (e.g. USB).
+ * while connected to the board's hardware serial (typically over USB).
  * 
  * TODO: Link basic setup here (board files, how to upload, how to pair Bluetooth, how to find and open port)
  */
@@ -15,6 +15,10 @@ void setup() {
 
 void loop() {
     AlfredoConnect.update();
-    if (AlfredoConnect.keyHeld(Key::W)) digitalWrite(LED_BUILTIN, HIGH);
-    else digitalWrite(LED_BUILTIN, LOW);
+
+    if (AlfredoConnect.keyHeld(Key::W)) {
+        digitalWrite(LED_BUILTIN, HIGH);
+    } else {
+        digitalWrite(LED_BUILTIN, LOW);
+    }
 }


### PR DESCRIPTION
Four examples added and tested for Uno:
 * `LEDControlSerial.ino`: Turns on an LED when "W" is pressed, connected over hardware serial, typically USB.
 * `LEDControlBluetooth.ino`: Turns on an LED when "W" is pressed, connected over software serial, typically Bluetooth.
 * `DefaultArcadeBotKeyboard.ino`: Runs motors on an Adafruit Motor Shield v1 in arcade drive, controlled using WASD on the keyboard.
 * `DefaultArcadeBotGamepad.ino`: Runs motors on an Adafruit Motor Shield v1 in arcade drive, controlled using a gamepad.