### PR TITLE
Only include `AlfredoConnect.h` by default

### DIFF
--- a/.github/workflows/Arduino-lint.yml
+++ b/.github/workflows/Arduino-lint.yml
@@ -7,3 +7,5 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: arduino/arduino-lint-action@v1
+        with:
+          library-manager: update

--- a/library.properties
+++ b/library.properties
@@ -7,3 +7,4 @@ paragraph=This library runs on a robot so it can be controlled by a driver with 
 category=Device Control
 url=https://github.com/AlfredoSystems/AlfredoConnect-Receive
 architectures=*
+includes=AlfredoConnect.h


### PR DESCRIPTION
Change `library.properties` to only include `AlfredoConnect.h` and not `Keys.h` by default when using **Include Library...** in Arduino.